### PR TITLE
[Crit][Major][Minor] Контент карточек контактов выходит за пределы контейнера в Хроме. Иконка поиска выходит за пределы страницы на экранах w < 345px. Неполная граница карточек контактов в Хроме.

### DIFF
--- a/static/styles/less/contact.less
+++ b/static/styles/less/contact.less
@@ -5,6 +5,9 @@
 
 	& > .card {
 		display: grid;
+
+		height: max-content !important;
+
 		margin-bottom: 26px;
 
 		& > img {
@@ -76,6 +79,11 @@
 
 			& > .contact-info {
 				font-size: 0.9rem;
+
+				& > .list-group-item:last-child {
+					border-bottom: none;
+				}
+
 			}
 		}
 

--- a/static/styles/less/header.less
+++ b/static/styles/less/header.less
@@ -1,7 +1,7 @@
 #header {
 	display: grid;
 	
-	column-gap: 65px;
+	column-gap: 56px;
 	padding-bottom: 10px;
 	
 	@media (min-width: @xs-breakpoint){
@@ -11,6 +11,10 @@
 				
 		row-gap: 0;
 		box-shadow: 0px 5px 5px rgba(0,0,0,0.1);
+	}
+
+	@media (min-width: @s-breakpoint) {
+		column-gap: 65px;
 	}
 
 	@media (min-width: @lg-breakpoint){    


### PR DESCRIPTION
Contact card's height now is set to max-content. Last contact item no longer has bottom border. Column gap in header is now set to 56px on extra small screens.